### PR TITLE
Adding PLUG mirror to list of mirrors

### DIFF
--- a/vm-dflybsd-cloud-DragonflyBSD-hammer-x64-6.conf
+++ b/vm-dflybsd-cloud-DragonflyBSD-hammer-x64-6.conf
@@ -17,7 +17,9 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
+
 
 iso_img="DragonflyBSD-hammer-x64-6.2.2.raw"
 iso_img_dist="DragonflyBSD-hammer-x64-6.2.2.raw.xz"

--- a/vm-dflybsd-x86-6.conf
+++ b/vm-dflybsd-x86-6.conf
@@ -28,7 +28,8 @@ https://mirror.epn.edu.ec/dragonflybsd/iso-images/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="dfly-x86_64-6.2.2_REL.iso"
 iso_img_dist="dfly-x86_64-6.2.2_REL.iso.bz2"

--- a/vm-freebsd-FreeBSD-aarch64-13.0.conf
+++ b/vm-freebsd-FreeBSD-aarch64-13.0.conf
@@ -23,7 +23,8 @@ ftp://ftp1.us.freebsd.org/pub/FreeBSD/releases/VM-IMAGES/13.0-RELEASE/aarch64/La
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="FreeBSD-13.0-RELEASE-arm64-aarch64.raw"
 iso_img_dist="FreeBSD-13.0-RELEASE-arm64-aarch64.raw.xz"

--- a/vm-freebsd-FreeBSD-riscv64-13.0.conf
+++ b/vm-freebsd-FreeBSD-riscv64-13.0.conf
@@ -23,7 +23,8 @@ ftp://ftp1.us.freebsd.org/pub/FreeBSD/releases/VM-IMAGES/13.0-RELEASE/riscv64/La
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="FreeBSD-13.0-RELEASE-riscv-riscv64.raw"
 iso_img_dist="FreeBSD-13.0-RELEASE-riscv-riscv64.raw.xz"

--- a/vm-freebsd-FreeBSD-x64-12.3.conf
+++ b/vm-freebsd-FreeBSD-x64-12.3.conf
@@ -22,7 +22,8 @@ ftp://ftp1.us.freebsd.org/pub/FreeBSD/releases/amd64/amd64/ISO-IMAGES/12.3/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="FreeBSD-12.3-RELEASE-amd64-disc1.iso"
 iso_img_dist="FreeBSD-12.3-RELEASE-amd64-disc1.iso.xz"

--- a/vm-freebsd-FreeBSD-x64-13.0.conf
+++ b/vm-freebsd-FreeBSD-x64-13.0.conf
@@ -22,7 +22,8 @@ ftp://ftp1.us.freebsd.org/pub/FreeBSD/releases/amd64/amd64/ISO-IMAGES/13.0/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="FreeBSD-13.0-RELEASE-amd64-disc1.iso"
 iso_img_dist="FreeBSD-13.0-RELEASE-amd64-disc1.iso.xz"

--- a/vm-freebsd-FreeBSD-x64-13.1.conf
+++ b/vm-freebsd-FreeBSD-x64-13.1.conf
@@ -22,7 +22,8 @@ ftp://ftp1.us.freebsd.org/pub/FreeBSD/releases/amd64/amd64/ISO-IMAGES/13.1/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="FreeBSD-13.1-RELEASE-amd64-disc1.iso"
 iso_img_dist="FreeBSD-13.1-RELEASE-amd64-disc1.iso.xz"

--- a/vm-freebsd-FreeBSD-x64-14.0-LATEST.conf
+++ b/vm-freebsd-FreeBSD-x64-14.0-LATEST.conf
@@ -18,7 +18,8 @@ ftp://ftp.freebsd.org/pub/FreeBSD/snapshots/amd64/amd64/ISO-IMAGES/14.0/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="FreeBSD-14.0-CURRENT-amd64-20220708-a0b956f5ac5-256605-disc1.iso"
 iso_img_dist="FreeBSD-14.0-CURRENT-amd64-20220708-a0b956f5ac5-256605-disc1.iso.xz"

--- a/vm-freebsd-GhostBSD-x64-22.conf
+++ b/vm-freebsd-GhostBSD-x64-22.conf
@@ -30,7 +30,8 @@ https://download.za.ghostbsd.org/releases/amd64/22.06.15/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="GhostBSD-22.06.15.iso"
 

--- a/vm-freebsd-HardenedBSD-x64-13-STABLE.conf
+++ b/vm-freebsd-HardenedBSD-x64-13-STABLE.conf
@@ -17,7 +17,8 @@ iso_site="https://ci-01.nyi.hardenedbsd.org/pub/hardenedbsd/13-stable/amd64/amd6
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="disc1.iso"
 iso_img_dist=

--- a/vm-freebsd-MidnightBSD-x64-2.conf
+++ b/vm-freebsd-MidnightBSD-x64-2.conf
@@ -21,7 +21,8 @@ https://www.midnightbsd.org/ftp/MidnightBSD/releases/amd64/ISO-IMAGES/2.2.0/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="MidnightBSD-2.2.0--amd64-disc1.iso"
 iso_img_dist=

--- a/vm-freebsd-OPNsense-22-RELEASE-amd64.conf
+++ b/vm-freebsd-OPNsense-22-RELEASE-amd64.conf
@@ -27,7 +27,8 @@ http://mirror.dataroute.de/opnsense/releases/22.1/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="OPNsense-22.1.2-OpenSSL-dvd-amd64.iso"
 iso_img_dist="OPNsense-22.1.2-OpenSSL-dvd-amd64.iso.bz2"

--- a/vm-freebsd-TrueNAS-CORE-x64-13.conf
+++ b/vm-freebsd-TrueNAS-CORE-x64-13.conf
@@ -16,7 +16,8 @@ iso_site="https://download.freenas.org/13.0/STABLE/RELEASE/x64/"
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="TrueNAS-13.0-RELEASE.iso"
 

--- a/vm-freebsd-XigmaNAS-12.conf
+++ b/vm-freebsd-XigmaNAS-12.conf
@@ -23,7 +23,8 @@ https://svwh.dl.sourceforge.net/project/xigmanas/XigmaNAS-12.3.0.4/12.3.0.4.9047
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="XigmaNAS-x64-LiveCD-12.3.0.4.9047.iso"
 

--- a/vm-freebsd-cloud-FreeBSD-ufs-x64-12.3.conf
+++ b/vm-freebsd-cloud-FreeBSD-ufs-x64-12.3.conf
@@ -17,7 +17,9 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
+
 
 iso_img="FreeBSD-ufs-12.3.1-RELEASE-amd64.raw"
 iso_img_dist="FreeBSD-ufs-12.3.1-RELEASE-amd64.raw.xz"

--- a/vm-freebsd-cloud-FreeBSD-ufs-x64-13.0.conf
+++ b/vm-freebsd-cloud-FreeBSD-ufs-x64-13.0.conf
@@ -17,7 +17,9 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
+
 
 iso_img="FreeBSD-ufs-13.0.2-RELEASE-amd64.raw"
 iso_img_dist="FreeBSD-ufs-13.0.2-RELEASE-amd64.raw.xz"

--- a/vm-freebsd-cloud-FreeBSD-ufs-x64-13.1.conf
+++ b/vm-freebsd-cloud-FreeBSD-ufs-x64-13.1.conf
@@ -17,7 +17,9 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
+
 
 iso_img="FreeBSD-ufs-13.1.0-RELEASE-amd64.raw"
 iso_img_dist="FreeBSD-ufs-13.1.0-RELEASE-amd64.raw.xz"

--- a/vm-freebsd-cloud-FreeBSD-ufs-x64-14.conf
+++ b/vm-freebsd-cloud-FreeBSD-ufs-x64-14.conf
@@ -17,7 +17,9 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
+
 
 iso_img="FreeBSD-ufs-14.0.2-CURRENT-amd64.raw"
 iso_img_dist="FreeBSD-ufs-14.0.2-CURRENT-amd64.raw.xz"

--- a/vm-freebsd-cloud-FreeBSD-zfs-x64-12.3.conf
+++ b/vm-freebsd-cloud-FreeBSD-zfs-x64-12.3.conf
@@ -16,7 +16,9 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
+
 
 iso_img="FreeBSD-zfs-12.3.1-RELEASE-amd64.raw"
 iso_img_dist="FreeBSD-zfs-12.3.1-RELEASE-amd64.raw.xz"

--- a/vm-freebsd-cloud-FreeBSD-zfs-x64-13.0.conf
+++ b/vm-freebsd-cloud-FreeBSD-zfs-x64-13.0.conf
@@ -17,7 +17,9 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
+
 
 iso_img="FreeBSD-zfs-13.0.2-RELEASE-amd64.raw"
 iso_img_dist="FreeBSD-zfs-13.0.2-RELEASE-amd64.raw.xz"

--- a/vm-freebsd-cloud-FreeBSD-zfs-x64-13.1.conf
+++ b/vm-freebsd-cloud-FreeBSD-zfs-x64-13.1.conf
@@ -17,7 +17,9 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
+
 
 iso_img="FreeBSD-zfs-13.1.0-RELEASE-amd64.raw"
 iso_img_dist="FreeBSD-zfs-13.1.0-RELEASE-amd64.raw.xz"

--- a/vm-freebsd-cloud-FreeBSD-zfs-x64-14.conf
+++ b/vm-freebsd-cloud-FreeBSD-zfs-x64-14.conf
@@ -17,7 +17,9 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
+
 
 iso_img="FreeBSD-zfs-14.0.2-CURRENT-amd64.raw"
 iso_img_dist="FreeBSD-zfs-14.0.2-CURRENT-amd64.raw.xz"

--- a/vm-freebsd-cloud-OPNSense-22-RELEASE-amd64-22.conf
+++ b/vm-freebsd-cloud-OPNSense-22-RELEASE-amd64-22.conf
@@ -16,7 +16,9 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
+
 
 iso_img="OPNSense-22-RELEASE-amd64.raw"
 iso_img_dist="OPNSense-22-RELEASE-amd64.raw.xz"

--- a/vm-freebsd-helloSystem-x64.conf
+++ b/vm-freebsd-helloSystem-x64.conf
@@ -18,7 +18,8 @@ https://github.com/helloSystem/ISO/releases/download/experimental-13.1/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="hello-0.8.0_0H78-FreeBSD-13.1-amd64.iso"
 

--- a/vm-freebsd-pfSense-2-RELEASE-amd64.conf
+++ b/vm-freebsd-pfSense-2-RELEASE-amd64.conf
@@ -25,7 +25,8 @@ http://files.uk.pfsense.org/mirror/downloads/old/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="pfSense-CE-${pfver}-amd64.iso"
 iso_img_dist="pfSense-CE-${pfver}-amd64.iso.gz"

--- a/vm-linux-AlmaLinux-9-x86_64.conf
+++ b/vm-linux-AlmaLinux-9-x86_64.conf
@@ -26,7 +26,8 @@ http://mirror.siena.edu/almalinux/9.0/isos/x86_64/ \
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
 #  electrode.bsdstore.ru: Edgar
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="AlmaLinux-9-latest-x86_64-dvd.iso"
 

--- a/vm-linux-Alpine-extended-3.conf
+++ b/vm-linux-Alpine-extended-3.conf
@@ -21,7 +21,8 @@ https://mirrors.aliyun.com/alpine/v3.15/releases/x86_64/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="alpine-extended-3.15.4-x86_64.iso"
 

--- a/vm-linux-Alpine-standart-3.conf
+++ b/vm-linux-Alpine-standart-3.conf
@@ -21,7 +21,8 @@ https://mirrors.aliyun.com/alpine/v3.15/releases/x86_64/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="alpine-standard-3.15.4-x86_64.iso"
 

--- a/vm-linux-ArchLinux-x86-2022.conf
+++ b/vm-linux-ArchLinux-x86-2022.conf
@@ -27,7 +27,8 @@ https://mirror.us.leaseweb.net/archlinux/iso/2022.05.01/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="archlinux-2022.05.01-x86_64.iso"
 

--- a/vm-linux-CentOS-7-x86_64.conf
+++ b/vm-linux-CentOS-7-x86_64.conf
@@ -27,7 +27,8 @@ http://ftp.neowiz.com/centos/7.9.2009/isos/x86_64/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="CentOS-7-x86_64-DVD-2009.iso"
 

--- a/vm-linux-CentOS-stream-8-x86_64.conf
+++ b/vm-linux-CentOS-stream-8-x86_64.conf
@@ -25,7 +25,8 @@ http://mirror.sale-dedic.com/centos/8-stream/isos/x86_64/ \
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
 #  electrode.bsdstore.ru: Edgar
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="CentOS-Stream-8-x86_64-20220506-dvd1.iso"
 

--- a/vm-linux-CentOS-stream-9-x86_64.conf
+++ b/vm-linux-CentOS-stream-9-x86_64.conf
@@ -23,7 +23,8 @@ http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/iso/ \
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
 #  electrode.bsdstore.ru: Edgar
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="CentOS-Stream-9-20220509.0-x86_64-dvd1.iso"
 

--- a/vm-linux-ClearLinux-Server-x86_64.conf
+++ b/vm-linux-ClearLinux-Server-x86_64.conf
@@ -18,7 +18,8 @@ iso_site="https://cdn.download.clearlinux.org/releases/36280/clear/"
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
 #  electrode.bsdstore.ru: Edgar
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="clear-36280-live-server.iso"
 

--- a/vm-linux-Debian-x86-10.conf
+++ b/vm-linux-Debian-x86-10.conf
@@ -17,7 +17,8 @@ iso_site="https://cdimage.debian.org/mirror/cdimage/archive/10.11.0/amd64/iso-dv
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 torrent="debian-10.11.0-amd64-DVD-1.iso.torrent"
 

--- a/vm-linux-Debian-x86-11.conf
+++ b/vm-linux-Debian-x86-11.conf
@@ -25,7 +25,8 @@ http://debian.cse.msu.edu/debian-cd/11.4.0/amd64/iso-dvd/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 torrent="debian-11.4.0-amd64-DVD-1.iso.torrent"
 iso_img="debian-11.4.0-amd64-DVD-1.iso"

--- a/vm-linux-FreePBX-64bit-16.conf
+++ b/vm-linux-FreePBX-64bit-16.conf
@@ -17,7 +17,8 @@ iso_site="https://downloads.freepbxdistro.org/ISO/"
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="SNG7-PBX16-64bit-2204-1.iso"
 

--- a/vm-linux-Kali-2022-amd64.conf
+++ b/vm-linux-Kali-2022-amd64.conf
@@ -20,7 +20,8 @@ http://mirror-1.truenetwork.ru/kali-images/kali-2022.2/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="kali-linux-2022.2-installer-amd64.iso"
 

--- a/vm-linux-Mint-20.conf
+++ b/vm-linux-Mint-20.conf
@@ -28,7 +28,8 @@ https://mint.zero.com.ar/mintcd/stable/20.3/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="linuxmint-20.3-cinnamon-64bit.iso"
 

--- a/vm-linux-OracleLinux-7.conf
+++ b/vm-linux-OracleLinux-7.conf
@@ -21,7 +21,8 @@ http://ftp.icm.edu.pl/pub/Linux/dist/oracle-linux/OL7/u9/x86_64/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="OracleLinux-R7-U9-Server-x86_64-dvd.iso"
 

--- a/vm-linux-OracleLinux-8.conf
+++ b/vm-linux-OracleLinux-8.conf
@@ -24,7 +24,8 @@ http://ftp.icm.edu.pl/pub/Linux/dist/oracle-linux/OL8/u6/x86_64/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="OracleLinux-R8-U6-x86_64-dvd.iso"
 

--- a/vm-linux-OracleLinux-9.conf
+++ b/vm-linux-OracleLinux-9.conf
@@ -24,7 +24,8 @@ http://ftp.icm.edu.pl/pub/Linux/dist/oracle-linux/OL9/u0/x86_64/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="OracleLinux-R9-U0-x86_64-dvd.iso"
 

--- a/vm-linux-Parrot-security-5-x64.conf
+++ b/vm-linux-Parrot-security-5-x64.conf
@@ -22,7 +22,8 @@ https://mirrors.ocf.berkeley.edu/parrot/iso/5.0/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="Parrot-home-5.0_amd64.iso"
 

--- a/vm-linux-Rocky-8-x86_64.conf
+++ b/vm-linux-Rocky-8-x86_64.conf
@@ -20,7 +20,8 @@ https://download.rockylinux.org/pub/rocky/8/isos/x86_64/ \
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
 #  electrode.bsdstore.ru: Edgar
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="Rocky-8.6-x86_64-dvd1.iso"
 

--- a/vm-linux-Rocky-9-x86_64.conf
+++ b/vm-linux-Rocky-9-x86_64.conf
@@ -23,7 +23,8 @@ http://mirror.in2p3.fr/pub/linux/rocky/9.0/isos/x86_64/ \
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
 #  electrode.bsdstore.ru: Edgar
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="Rocky-9.0-x86_64-dvd.iso"
 

--- a/vm-linux-TinyCore-x86-13.conf
+++ b/vm-linux-TinyCore-x86-13.conf
@@ -22,7 +22,8 @@ http://ftp.nluug.nl/os/Linux/distr/tinycorelinux/13.x/x86_64/release/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="TinyCorePure64-13.1.iso"
 

--- a/vm-linux-TrueNAS-Scale-22.conf
+++ b/vm-linux-TrueNAS-Scale-22.conf
@@ -17,7 +17,8 @@ iso_site="https://download.truenas.com/TrueNAS-SCALE-Angelfish/22.02.0.1/"
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="TrueNAS-SCALE-22.02.0.1.iso"
 

--- a/vm-linux-cloud-Alma-9-x86_64.conf
+++ b/vm-linux-cloud-Alma-9-x86_64.conf
@@ -15,7 +15,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 # case incompatible with merge_profiles
 #case "${emulator}" in

--- a/vm-linux-cloud-CentOS-7-x86_64.conf
+++ b/vm-linux-cloud-CentOS-7-x86_64.conf
@@ -15,7 +15,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 # case incompatible with merge_profiles
 #case "${emulator}" in

--- a/vm-linux-cloud-CentOS-stream-8-x86_64.conf
+++ b/vm-linux-cloud-CentOS-stream-8-x86_64.conf
@@ -15,7 +15,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 # case incompatible with merge_profiles
 #case "${emulator}" in

--- a/vm-linux-cloud-CentOS-stream-9-x86_64.conf
+++ b/vm-linux-cloud-CentOS-stream-9-x86_64.conf
@@ -15,7 +15,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 # case incompatible with merge_profiles
 #case "${emulator}" in

--- a/vm-linux-cloud-Debian-x86-10.conf
+++ b/vm-linux-cloud-Debian-x86-10.conf
@@ -15,7 +15,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 # case incompatible with merge_profiles
 #case "${emulator}" in

--- a/vm-linux-cloud-Debian-x86-11.conf
+++ b/vm-linux-cloud-Debian-x86-11.conf
@@ -15,7 +15,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 iso_img="cloud-Debian-x86-11.4.0.raw"
 iso_img_dist="${iso_img}.xz"

--- a/vm-linux-cloud-Debian-x86-9.conf
+++ b/vm-linux-cloud-Debian-x86-9.conf
@@ -15,7 +15,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 iso_img="cloud-Debian-x86-9.11.0.raw"
 iso_img_dist="cloud-Debian-x86-9.11.0.raw.xz"

--- a/vm-linux-cloud-Fedora-36-x86_64.conf
+++ b/vm-linux-cloud-Fedora-36-x86_64.conf
@@ -15,7 +15,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 # case incompatible with merge_profiles
 #case "${emulator}" in

--- a/vm-linux-cloud-FreePBX-16-x86_64.conf
+++ b/vm-linux-cloud-FreePBX-16-x86_64.conf
@@ -15,7 +15,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 # case incompatible with merge_profiles
 #case "${emulator}" in

--- a/vm-linux-cloud-HomeAssistant-8.conf
+++ b/vm-linux-cloud-HomeAssistant-8.conf
@@ -15,7 +15,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 iso_img="cloud-HomeAssistant-8.raw"
 iso_img_dist="${iso_img}.xz"

--- a/vm-linux-cloud-Kali-2022-amd64.conf
+++ b/vm-linux-cloud-Kali-2022-amd64.conf
@@ -15,7 +15,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 iso_img="cloud-Kali-2022-amd64.raw"
 iso_img_dist="${iso_img}.xz"

--- a/vm-linux-cloud-Oracle-7-x86_64.conf
+++ b/vm-linux-cloud-Oracle-7-x86_64.conf
@@ -15,7 +15,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 # case incompatible with merge_profiles
 #case "${emulator}" in

--- a/vm-linux-cloud-Oracle-8-x86_64.conf
+++ b/vm-linux-cloud-Oracle-8-x86_64.conf
@@ -15,7 +15,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 # case incompatible with merge_profiles
 #case "${emulator}" in

--- a/vm-linux-cloud-Oracle-9-x86_64.conf
+++ b/vm-linux-cloud-Oracle-9-x86_64.conf
@@ -15,7 +15,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 iso_img="Oracle-9.0.0-x86_64-cloud.raw"
 iso_img_dist="${iso_img}.xz"

--- a/vm-linux-cloud-Rocky-8-x86_64.conf
+++ b/vm-linux-cloud-Rocky-8-x86_64.conf
@@ -15,7 +15,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 # case incompatible with merge_profiles
 #case "${emulator}" in

--- a/vm-linux-cloud-Rocky-9-x86_64.conf
+++ b/vm-linux-cloud-Rocky-9-x86_64.conf
@@ -15,7 +15,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 iso_img="Rocky-90-x86_64-cloud.raw"
 iso_img_dist="${iso_img}.xz"

--- a/vm-linux-cloud-kubernetes-24.conf
+++ b/vm-linux-cloud-kubernetes-24.conf
@@ -20,7 +20,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 iso_img="cloud-kubernetes-24.raw"
 iso_img_dist="cloud-kubernetes-24.raw.xz"

--- a/vm-linux-cloud-ubuntudesktop-amd64-22.04.conf
+++ b/vm-linux-cloud-ubuntudesktop-amd64-22.04.conf
@@ -16,7 +16,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 iso_img="cloud-Ubuntu-vdi-x86-22.04.raw"
 iso_img_dist="cloud-Ubuntu-vdi-x86-22.04.raw.xz"

--- a/vm-linux-cloud-ubuntuserver-amd64-20.04.conf
+++ b/vm-linux-cloud-ubuntuserver-amd64-20.04.conf
@@ -20,7 +20,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 iso_img="cloud-Ubuntu-x86-20.04.2.raw"
 iso_img_dist="cloud-Ubuntu-x86-20.04.2.raw.xz"

--- a/vm-linux-cloud-ubuntuserver-amd64-22.04.conf
+++ b/vm-linux-cloud-ubuntuserver-amd64-22.04.conf
@@ -16,7 +16,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 iso_img="cloud-Ubuntu-x86-22.04.raw"
 iso_img_dist="cloud-Ubuntu-x86-22.04.raw.xz"

--- a/vm-linux-fedora-server-35-x86_64.conf
+++ b/vm-linux-fedora-server-35-x86_64.conf
@@ -28,7 +28,8 @@ http://mirror.cs.princeton.edu/pub/mirrors/fedora/linux/releases/35/Server/x86_6
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="Fedora-Server-dvd-x86_64-35-1.2.iso"
 

--- a/vm-linux-fedora-server-36-x86_64.conf
+++ b/vm-linux-fedora-server-36-x86_64.conf
@@ -28,7 +28,8 @@ http://mirror.cs.princeton.edu/pub/mirrors/fedora/linux/releases/36/Server/x86_6
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="Fedora-Server-dvd-x86_64-36-1.5.iso"
 

--- a/vm-linux-opensuse-leap-15-x86.conf
+++ b/vm-linux-opensuse-leap-15-x86.conf
@@ -29,7 +29,8 @@ https://download.opensuse.org/distribution/leap/15.4/iso/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="openSUSE-Leap-15.4-DVD-x86_64-Build243.2-Media.iso"
 

--- a/vm-linux-ubuntu-desktop-amd64-21.conf
+++ b/vm-linux-ubuntu-desktop-amd64-21.conf
@@ -27,7 +27,8 @@ http://mirror.waia.asn.au/ubuntu-releases/21.10/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="ubuntu-21.10-desktop-amd64.iso"
 

--- a/vm-linux-ubuntu-desktop-amd64-22.conf
+++ b/vm-linux-ubuntu-desktop-amd64-22.conf
@@ -27,7 +27,8 @@ http://mirror.waia.asn.au/ubuntu-releases/22.04/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="ubuntu-22.04-desktop-amd64.iso"
 

--- a/vm-linux-ubuntuserver-amd64-20.04.conf
+++ b/vm-linux-ubuntuserver-amd64-20.04.conf
@@ -27,7 +27,8 @@ http://mirror.waia.asn.au/ubuntu-releases/20.04.4/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="ubuntu-20.04.4-live-server-amd64.iso"
 

--- a/vm-linux-ubuntuserver-amd64-22.conf
+++ b/vm-linux-ubuntuserver-amd64-22.conf
@@ -26,7 +26,8 @@ http://mirror.waia.asn.au/ubuntu-releases/22.04/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="ubuntu-22.04-live-server-amd64.iso"
 

--- a/vm-linux-vyos-1.4.conf
+++ b/vm-linux-vyos-1.4.conf
@@ -17,7 +17,8 @@ https://downloads.vyos.io/rolling/current/amd64/"
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="vyos-1.4-rolling-202204240217-amd64.iso"
 

--- a/vm-netbsd-cloud-netbsd-x86-9.conf
+++ b/vm-netbsd-cloud-netbsd-x86-9.conf
@@ -15,7 +15,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 iso_img="netbsd-9.2a.raw"
 iso_img_dist="netbsd-9.2a.raw.xz"

--- a/vm-netbsd-x86-9.conf
+++ b/vm-netbsd-x86-9.conf
@@ -21,7 +21,8 @@ http://www.nic.funet.fi/pub/NetBSD/NetBSD-9.2/images/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 #iso_img="NetBSD-9.2-amd64-uefi-install.img"
 #iso_img_dist="NetBSD-9.2-amd64-uefi-install.img.gz"

--- a/vm-openbsd-cloud-openbsd-x86-7.conf
+++ b/vm-openbsd-cloud-openbsd-x86-7.conf
@@ -15,7 +15,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 iso_img="openbsd-71.raw"
 iso_img_dist="openbsd-71.raw.xz"

--- a/vm-openbsd-cloud-openbsd-x86-70.conf
+++ b/vm-openbsd-cloud-openbsd-x86-70.conf
@@ -15,7 +15,8 @@ iso_site="https://mirror.bsdstore.ru/cloud/"
 #  electrode.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/cloud/ http://electrode.bsdstore.ru/cloud/ https://clonos.us.ircdriven.net/cloud/ https://clonos.ca.ircdriven.net/cloud/ https://electrode.bsdstore.ru/cloud/ https://plug-mirror.rcac.purdue.edu/cbsd/cloud/"
 
 iso_img="openbsd-70.raw"
 iso_img_dist="openbsd-70.raw.xz"

--- a/vm-openbsd-x86-6.conf
+++ b/vm-openbsd-x86-6.conf
@@ -23,7 +23,8 @@ http://mirror.internode.on.net/pub/OpenBSD/6.9/amd64/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="install69.img"
 

--- a/vm-openbsd-x86-7.conf
+++ b/vm-openbsd-x86-7.conf
@@ -23,7 +23,8 @@ http://mirror.internode.on.net/pub/OpenBSD/7.1/amd64/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="install71.img"
 

--- a/vm-other-Haiku-r1.conf
+++ b/vm-other-Haiku-r1.conf
@@ -18,7 +18,8 @@ iso_site="\
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="haiku-master-hrev54571-x86_64-anyboot.iso"
 iso_img_dist="haiku-master-hrev54571-x86_64-anyboot.zip"

--- a/vm-other-Minoca.conf
+++ b/vm-other-Minoca.conf
@@ -17,7 +17,8 @@ iso_site="https://www.minocacorp.com/download/0.4/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="pcefi.img"
 iso_img_dist="Minoca-pcefi.zip"

--- a/vm-other-OpenIndiana-2021.conf
+++ b/vm-other-OpenIndiana-2021.conf
@@ -22,7 +22,8 @@ iso_img="OI-hipster-gui-20211031.iso"
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_extract=""
 

--- a/vm-other-ReactOS.conf
+++ b/vm-other-ReactOS.conf
@@ -22,7 +22,8 @@ https://datapacket.dl.sourceforge.net/project/reactos/ReactOS/0.4.14/ \
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="ReactOS-0.4.14-Live.iso"
 iso_img_dist="ReactOS-0.4.14-live.zip"

--- a/vm-other-omnios-2022.conf
+++ b/vm-other-omnios-2022.conf
@@ -18,7 +18,8 @@ https://us-west.mirror.omniosce.org/downloads/media/stable/"
 #  electro.bsdstore.ru: olevole at olevole dot ru
 #  mirror.bsdstore.ru: olevole at olevole dot ru
 #  clonos.ca.ircdriven.net clonos.us.ircdriven.net: onecoldworld at gmail dot com
-cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/"
+#  plug-mirror.rcac.purdue.edu: plug-mirror at lists dot purdue dot edu
+cbsd_iso_mirrors="https://mirror2.bsdstore.ru/iso/ http://electro.bsdstore.ru/iso/ https://mirror.bsdstore.ru/iso/ https://clonos.ca.ircdriven.net/iso/ https://clonos.us.ircdriven.net/iso/ https://electrode.bsdstore.ru/iso/ https://plug-mirror.rcac.purdue.edu/cbsd/iso/"
 
 iso_img="omnios-r151042.iso"
 


### PR DESCRIPTION
Requesting to add the Purdue Linux Users Group mirror to the list of mirrors.
We are configured to mirror electro.bsdstore.ru::iso and electro.bsdstore.ru::cloud 4 times every day.

Organization name: Purdue Linux Users Group
Web page URL of the organization: http://purduelug.org/
Location: West Lafayette, Indiana, United States
Point of contact (person): June Slater / igloo[at]igloo.to
Point of contact (mirror maintainers list): plug-mirror[at]lists.purdue.edu
Mirror Server's URL: https://plug-mirror.rcac.purdue.edu/ (files will be at https://plug-mirror.rcac.purdue.edu/cbsd/ ; HTTP, HTTPS, FTP, and RSYNC are supported)
Additional mirror information: https://plug-mirror.rcac.purdue.edu/info.html
